### PR TITLE
Add Dockerfile for testing

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -3,3 +3,4 @@
 img
 data-raw
 cran_graphs.R
+Dockerfile

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,11 @@
+FROM rocker/r-devel
+MAINTAINER Noam Ross noam.ross@gmail.com
+
+RUN wget https://github.com/jgm/pandoc/releases/download/1.16.0.2/pandoc-1.16.0.2-1-amd64.deb && \
+    dpkg -i pandoc* && \
+    rm pandoc* && \
+    apt-get clean
+
+RUN install2.r -r http://cran.rstudio.com \
+    hexbin \
+    ggplot2


### PR DESCRIPTION
Note that the Dockerfile includes ggplot and hexbin packages, which won't be needed if we remove the ggplot examples from documentation in this package.
