### PR TITLE
Added some testing boilerplate code

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -4,3 +4,5 @@ img
 data-raw
 cran_graphs.R
 Dockerfile
+^\.travis\.yml$
+^codecov\.yml$

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,8 @@
+# R for travis: see documentation at https://docs.travis-ci.com/user/languages/r
+
+language: R
+sudo: false
+cache: packages
+
+after_success:
+  - Rscript -e 'covr::codecov()'

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,5 +4,10 @@ language: R
 sudo: false
 cache: packages
 
+r:
+ - oldrel
+ - release
+ - devel
+
 after_success:
   - Rscript -e 'covr::codecov()'

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -6,7 +6,7 @@ Date: 2017-03-03
 Authors@R: c(
       person("Simon", "Garnier", email = "garnier@njit.edu", role = c("aut", "cre")),
       person("Noam", "Ross", email = "noam.ross@gmail.com", role = c("ctb", "cph")),
-      person("Bob", "Rudis", email = "bob@rudis.net", role = c("ctb", "cph"))
+      person("Bob", "Rudis", email = "bob@rud.is", role = c("ctb", "cph"))
   )
 Maintainer: Simon Garnier <garnier@njit.edu>
 Description: Port of the new 'matplotlib' color maps ('viridis' - the default
@@ -27,7 +27,9 @@ Imports:
     grDevices
 Suggests:
     hexbin (>= 1.27.0),
-    ggplot2 (>= 1.0.1)
+    ggplot2 (>= 1.0.1),
+    testthat,
+    covr
 URL: https://github.com/sjmgarnier/viridisLite
 BugReports: https://github.com/sjmgarnier/viridisLite/issues
 RoxygenNote: 6.0.1

--- a/R/viridis.R
+++ b/R/viridis.R
@@ -65,22 +65,22 @@
 #' devices: see \code{\link[grDevices]{rgb}}.
 #'
 #' @examples
-# library(ggplot2)
-# library(hexbin)
-#
-# dat <- data.frame(x = rnorm(10000), y = rnorm(10000))
-#
-# ggplot(dat, aes(x = x, y = y)) +
-#   geom_hex() + coord_fixed() +
-#   scale_fill_gradientn(colours = viridis(256, option = "D"))
-#
-# # using code from RColorBrewer to demo the palette
-# n = 200
-# image(
-#   1:n, 1, as.matrix(1:n),
-#   col = viridis(n, option = "D"),
-#   xlab = "viridis n", ylab = "", xaxt = "n", yaxt = "n", bty = "n"
-# )
+#' library(ggplot2)
+#' library(hexbin)
+#'
+#' dat <- data.frame(x = rnorm(10000), y = rnorm(10000))
+#'
+#' ggplot(dat, aes(x = x, y = y)) +
+#'   geom_hex() + coord_fixed() +
+#'   scale_fill_gradientn(colours = viridis(256, option = "D"))
+#'
+#' # using code from RColorBrewer to demo the palette
+#' n = 200
+#' image(
+#'   1:n, 1, as.matrix(1:n),
+#'   col = viridis(n, option = "D"),
+#'   xlab = "viridis n", ylab = "", xaxt = "n", yaxt = "n", bty = "n"
+#' )
 #' @export
 #'
 viridis <- function(n, alpha = 1, begin = 0, end = 1, direction = 1, option = "D") {

--- a/R/viridis.R
+++ b/R/viridis.R
@@ -121,7 +121,7 @@ viridis <- function(n, alpha = 1, begin = 0, end = 1, direction = 1, option = "D
 #' \code{n = 256} by default, which corresponds to the data from the original
 #' 'viridis' color map in Matplotlib.
 #'
-viridisMap <- function(n = 256, alpha = 1, begin = 0, end = 1, direction = 1, option = "D") {
+viridisMap <- function(n = 256, alpha = 1, begin = 0, end = 1, direction = 1, option = "D") { # nocov start
   if (begin < 0 | begin > 1 | end < 0 | end > 1) {
     stop("begin and end must be in [0,1]")
   }
@@ -148,7 +148,7 @@ viridisMap <- function(n = 256, alpha = 1, begin = 0, end = 1, direction = 1, op
   fn_cols <- grDevices::colorRamp(map_cols, space = "Lab", interpolate = "spline")
   cols <- fn_cols(seq(begin, end, length.out = n)) / 255
   data.frame(R = cols[, 1], G = cols[, 2], B = cols[, 3], alpha = alpha)
-}
+} # nocov end
 
 #' @rdname viridis
 #' @export

--- a/R/viridis.R
+++ b/R/viridis.R
@@ -65,22 +65,22 @@
 #' devices: see \code{\link[grDevices]{rgb}}.
 #'
 #' @examples
-#' library(ggplot2)
-#' library(hexbin)
-#'
-#' dat <- data.frame(x = rnorm(10000), y = rnorm(10000))
-#'
-#' ggplot(dat, aes(x = x, y = y)) +
-#'   geom_hex() + coord_fixed() +
-#'   scale_fill_gradientn(colours = viridis(256, option = "D"))
-#'
-#' # using code from RColorBrewer to demo the palette
-#' n = 200
-#' image(
-#'   1:n, 1, as.matrix(1:n),
-#'   col = viridis(n, option = "D"),
-#'   xlab = "viridis n", ylab = "", xaxt = "n", yaxt = "n", bty = "n"
-#' )
+# library(ggplot2)
+# library(hexbin)
+#
+# dat <- data.frame(x = rnorm(10000), y = rnorm(10000))
+#
+# ggplot(dat, aes(x = x, y = y)) +
+#   geom_hex() + coord_fixed() +
+#   scale_fill_gradientn(colours = viridis(256, option = "D"))
+#
+# # using code from RColorBrewer to demo the palette
+# n = 200
+# image(
+#   1:n, 1, as.matrix(1:n),
+#   col = viridis(n, option = "D"),
+#   xlab = "viridis n", ylab = "", xaxt = "n", yaxt = "n", bty = "n"
+# )
 #' @export
 #'
 viridis <- function(n, alpha = 1, begin = 0, end = 1, direction = 1, option = "D") {

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 [![rstudio mirror downloads](http://cranlogs.r-pkg.org/badges/viridisLite)](https://github.com/metacran/cranlogs.app)
 [![cran version](http://www.r-pkg.org/badges/version/viridisLite)](http://cran.rstudio.com/web/packages/viridisLite)
+[![Travis-CI Build Status](https://travis-ci.org/hrbrmstr/viridisLite.svg?branch=master)](https://travis-ci.org/NA/viridisLite)
+[![Coverage Status](https://img.shields.io/codecov/c/github/hrbrmstr/viridisLite/master.svg)](https://codecov.io/github/hrbrmstr/viridisLite?branch=master)
 
 [Matplotlib](http://matplotlib.org/) recently [introduced new color maps]
 (http://matplotlib.org/style_changes.html) for their graphs. They are called

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,1 @@
+comment: false

--- a/man/viridis.Rd
+++ b/man/viridis.Rd
@@ -74,6 +74,24 @@ be passed as a function name.
 Semi-transparent colors (\eqn{0 < alpha < 1}) are supported only on some
 devices: see \code{\link[grDevices]{rgb}}.
 }
+\examples{
+library(ggplot2)
+library(hexbin)
+
+dat <- data.frame(x = rnorm(10000), y = rnorm(10000))
+
+ggplot(dat, aes(x = x, y = y)) +
+  geom_hex() + coord_fixed() +
+  scale_fill_gradientn(colours = viridis(256, option = "D"))
+
+# using code from RColorBrewer to demo the palette
+n = 200
+image(
+  1:n, 1, as.matrix(1:n),
+  col = viridis(n, option = "D"),
+  xlab = "viridis n", ylab = "", xaxt = "n", yaxt = "n", bty = "n"
+)
+}
 \author{
 Simon Garnier: \email{garnier@njit.edu}, \href{https://twitter.com/sjmgarnier}{@sjmgarnier}
 }

--- a/man/viridis.Rd
+++ b/man/viridis.Rd
@@ -74,24 +74,6 @@ be passed as a function name.
 Semi-transparent colors (\eqn{0 < alpha < 1}) are supported only on some
 devices: see \code{\link[grDevices]{rgb}}.
 }
-\examples{
-library(ggplot2)
-library(hexbin)
-
-dat <- data.frame(x = rnorm(10000), y = rnorm(10000))
-
-ggplot(dat, aes(x = x, y = y)) +
-  geom_hex() + coord_fixed() +
-  scale_fill_gradientn(colours = viridis(256, option = "D"))
-
-# using code from RColorBrewer to demo the palette
-n = 200
-image(
-  1:n, 1, as.matrix(1:n),
-  col = viridis(n, option = "D"),
-  xlab = "viridis n", ylab = "", xaxt = "n", yaxt = "n", bty = "n"
-)
-}
 \author{
 Simon Garnier: \email{garnier@njit.edu}, \href{https://twitter.com/sjmgarnier}{@sjmgarnier}
 }

--- a/tests/testthat.R
+++ b/tests/testthat.R
@@ -1,0 +1,4 @@
+library(testthat)
+library(viridisLite)
+
+test_check("viridisLite")

--- a/tests/testthat/test-palettes.R
+++ b/tests/testthat/test-palettes.R
@@ -1,0 +1,46 @@
+context("palette generation")
+test_that("palette generation is accurate", {
+
+  # data is intact
+  expect_equal(dim(viridis.map), c(1024, 4))
+
+  # options work as expected
+  expect_equal(viridis(1, option = "D"), "#440154FF")
+  expect_equal(viridis(1, alpha = 0, option = "D"), "#44015400")
+  expect_equal(viridis(1, begin = 1, end = 0, option = "D"), "#FDE725FF")
+  expect_equal(viridis(1, alpha = 0, begin = 1, end = 0, option = "D"), "#FDE72500")
+  expect_equal(viridis(2, alpha = 0, begin = 1, end = 0, direction = -1, option = "D"),
+               c("#44015400", "#FDE72500"))
+
+  # options work as expected
+  expect_equal(viridis(1, option = "C"), "#0D0887FF")
+  expect_equal(viridis(1, alpha = 0, option = "C"), "#0D088700")
+  expect_equal(viridis(1, begin = 1, end = 0, option = "C"), "#F0F921FF")
+  expect_equal(viridis(1, alpha = 0, begin = 1, end = 0, option = "C"), "#F0F92100")
+  expect_equal(viridis(2, alpha = 0, begin = 1, end = 0, direction = -1, option = "C"),
+               c("#0D088700", "#F0F92100"))
+
+  # options work as expected
+  expect_equal(viridis(1, option = "B"), "#000004FF")
+  expect_equal(viridis(1, alpha = 0, option = "B"), "#00000400")
+  expect_equal(viridis(1, begin = 1, end = 0, option = "B"), "#FCFFA4FF")
+  expect_equal(viridis(1, alpha = 0, begin = 1, end = 0, option = "B"), "#FCFFA400")
+  expect_equal(viridis(2, alpha = 0, begin = 1, end = 0, direction = -1, option = "B"),
+               c("#00000400", "#FCFFA400"))
+
+  # options work as expected
+  expect_equal(viridis(1, option = "A"), "#000004FF")
+  expect_equal(viridis(1, alpha = 0, option = "A"), "#00000400")
+  expect_equal(viridis(1, begin = 1, end = 0, option = "A"), "#FCFDBFFF")
+  expect_equal(viridis(1, alpha = 0, begin = 1, end = 0, option = "A"), "#FCFDBF00")
+  expect_equal(viridis(2, alpha = 0, begin = 1, end = 0, direction = -1, option = "A"),
+               c("#00000400", "#FCFDBF00"))
+
+  # we've already proven these work with ^^ but we'll add a few more values to
+  # generate and get better code coverage this way.
+
+  expect_equal(magma(3), c("#000004FF", "#B63679FF", "#FCFDBFFF"))
+  expect_equal(inferno(3), c("#000004FF", "#BB3754FF", "#FCFFA4FF"))
+  expect_equal(plasma(3), c("#0D0887FF", "#CC4678FF", "#F0F921FF"))
+
+})

--- a/tests/testthat/test-palettes.R
+++ b/tests/testthat/test-palettes.R
@@ -36,6 +36,14 @@ test_that("palette generation is accurate", {
   expect_equal(viridis(2, alpha = 0, begin = 1, end = 0, direction = -1, option = "A"),
                c("#00000400", "#FCFDBF00"))
 
+  # bad inputs
+  expect_warning(viridis(1, option = "E"))
+  expect_error(viridis(1, direction=100))
+  expect_error(viridis(1, begin = -1))
+  expect_error(viridis(1, begin = 100))
+  expect_error(viridis(1, end = -1))
+  expect_error(viridis(1, end = 100))
+
   # we've already proven these work with ^^ but we'll add a few more values to
   # generate and get better code coverage this way.
 


### PR DESCRIPTION
- added `covr` and `testthat` to `Suggests`
- added `testthat` framework skeleton
- added basic tests for all palettes, warnings and error conditions
- added README badges for Travis & Codecov
- code coverage is 100% if "nocov" is set on the internal (and unused) `viridisMap()` function
- all tests pass
- updated my e-mail in the `DESCRIPTION`
- modified `.Rbuildignore` for the code coverage config file (which was also added)

NOTE: You should prbly setup code-coverage/travis on the main repo and remove the references to `hrbrmstr` once this is final-final.