### PR TITLE
Small style and namespace tweaks

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -2,7 +2,6 @@ Package: viridisLite
 Type: Package
 Title: Default Color Maps from 'matplotlib' (Lite Version)
 Version: 0.2.0
-Date: 2017-03-03
 Authors@R: c(
       person("Simon", "Garnier", email = "garnier@njit.edu", role = c("aut", "cre")),
       person("Noam", "Ross", email = "noam.ross@gmail.com", role = c("ctb", "cph")),
@@ -22,9 +21,6 @@ LazyData: TRUE
 Encoding: UTF-8
 Depends:
     R (>= 2.10)
-Imports:
-    stats,
-    grDevices
 Suggests:
     hexbin (>= 1.27.0),
     ggplot2 (>= 1.0.1)

--- a/R/viridis.R
+++ b/R/viridis.R
@@ -152,19 +152,19 @@ viridisMap <- function(n = 256, alpha = 1, begin = 0, end = 1, direction = 1, op
 
 #' @rdname viridis
 #' @export
-magma = function(n, alpha = 1, begin = 0, end = 1, direction = 1) {
+magma <- function(n, alpha = 1, begin = 0, end = 1, direction = 1) {
   viridis(n, alpha, begin, end, direction, option = "magma")
 }
 
 #' @rdname viridis
 #' @export
-inferno = function(n, alpha = 1, begin = 0, end = 1, direction = 1) {
+inferno <- function(n, alpha = 1, begin = 0, end = 1, direction = 1) {
   viridis(n, alpha, begin, end, direction, option = "inferno")
 }
 
 #' @rdname viridis
 #' @export
-plasma = function(n, alpha = 1, begin = 0, end = 1, direction = 1) {
+plasma <- function(n, alpha = 1, begin = 0, end = 1, direction = 1) {
   viridis(n, alpha, begin, end, direction, option = "plasma")
 }
 


### PR DESCRIPTION
As you namespace all the base packages with `::` I remove the base packages from `Imports:`.

Also, changed out `=` for `<-` where appropriate.