### PR TITLE
mislabelled options for viridisMap()

### DIFF
--- a/R/viridis.R
+++ b/R/viridis.R
@@ -158,8 +158,8 @@ viridisMap <- function(n = 256, alpha = 1, begin = 0, end = 1, direction = 1, op
                    C = "C", plasma = "C",
                    D = "D", viridis = "D",
                    E = "E", cividis = "E",
-                   E = "F", rocket = "F",
-                   E = "G", mako = "G",
+                   F = "F", rocket = "F",
+                   G = "G", mako = "G",
                    {warning(paste0("Option '", option, "' does not exist. Defaulting to 'viridis'.")); "D"})
 
   map <- viridisLite::viridis.map[viridisLite::viridis.map$opt == option, ]


### PR DESCRIPTION
viridisMap had (erroneously?) mislabelled the options for rocket and mako...?

I cant tell if the author did that accidentally or on purpose because of the F == False mishap that was (seemingly?) going on above in the viridis() function